### PR TITLE
Add reference on how to build into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ uses [GNOME](https://www.gnome.org/) technologies, and so it has complete integr
 This software is licensed under the [GPL 3](https://github.com/gnome-pomodoro/gnome-pomodoro/blob/master/COPYING).
 
 *This project is not affiliated with, authorized by, sponsored by, or otherwise approved by GNOME Foundation and/or the Pomodoro Technique®. The GNOME logo and GNOME name are registered trademarks or trademarks of GNOME Foundation in the United States or other countries. The Pomodoro Technique® and Pomodoro™ are registered trademarks of Francesco Cirillo.*
+
+
+## Package download and building from source
+
+You can find detailed information under the Download section on our webpage https://gnomepomodoro.org/


### PR DESCRIPTION
## Pull request checklist

- [x] Lint and unit tests pass locally with my changes
- [x] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
I built the project personally a few years ago. I had to rebuild it this time again. I remembered not having any issues building it from source, but this time I struggled. I knew I wanted to build it from source, but I had no idea where the instructions for building are, so I had to search every library manually and how to build with Meson. After wasting too much time, and ready to download the pre-built binary, I realized that the build instructions are in the Download section, and it was the reason why I had no issues building it the last time.

I believe this happened because the Download section of the website suggests that you are about to download a pre-built binary for each distro. I was looking for installing a package or build instructions, not download, so I would claim it is unfortunately confusing. I checked the github readme and wiki, but nothing had any info on it.

Also, somewhat unrelated, but the project description on github uses HTTP link not HTTPS, not that it matters that much.

Issue Number: #592

## What is the new behavior?
Would it be possible to add just a small note that the build and package instructions can be found there? I believe we can then at least avoid some confusions in #592
(Write your answer here.)

## Other information

(Write your answer here.)
